### PR TITLE
Initialize dscore as a list

### DIFF
--- a/Apex2R.r
+++ b/Apex2R.r
@@ -75,7 +75,7 @@ sumStats$methods(
 
 		.self$initFields(
 			prefix = file_prefix,
-			dscore = sapply(ds, function(x) x[-c(1:4)]),
+			dscore = lapply(ds, function(x) x[-c(1:4)]),
 			dreg = dreg_t,
 			ds_gene = data.table::fread(sg_f),
 			vb = xzReader$new(vb_f),


### PR DESCRIPTION
When I tried running `sumStats()` with an example dataset, I got the following error:

```R
ss <- sumStats(prefix)
## Error: invalid assignment for reference class field ‘dscore’, should be from
## class “list” or a subclass (was class “matrix”)invalid assignment for reference
## class field ‘dscore’, should be from class “list” or a subclass (was class
## “array”)
```

Since you specified that dscore should be a list:

https://github.com/corbinq/apex2R/blob/742403b2ee2ee93b4b916775e5d7a667e9936965/Apex2R.r#L39

I changed `sapply()` to `lapply()` to avoid simplifying the list to a matrix:

https://github.com/corbinq/apex2R/blob/742403b2ee2ee93b4b916775e5d7a667e9936965/Apex2R.r#L78

After making this change, then I was able to import my example data with `sumStats()`.